### PR TITLE
Fixes #8. Move to use https submodule for gFTL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,2 +1,3 @@
-[submodule "gFTL"]
+[submodule "src/gFTL"]
+   path = gFTL
 	url = https://github.com/Goddard-Fortran-Ecosystem/gFTL.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,2 @@
-[submodule "src/gFTL"]
-	path = gFTL
-	url = git@github.com:Goddard-Fortran-Ecosystem/gFTL.git
+[submodule "gFTL"]
+	url = https://github.com/Goddard-Fortran-Ecosystem/gFTL.git


### PR DESCRIPTION
This PR moves from using an SSH url for gFTL to https.

I did two `git clone --recurse-submodules` of `master` and this branch and the code looks identical.