### PR TITLE
Updates for gfortran

### DIFF
--- a/cmake/GNU.cmake
+++ b/cmake/GNU.cmake
@@ -1,5 +1,5 @@
 set (FPP_FLAG -cpp)
-set (common_flags "${FPP_FLAG} -ffree-line-length-255")
+set (common_flags "${FPP_FLAG} -ffree-line-length-none")
 
 set (CMAKE_Fortran_FLAGS_RELEASE "${common_flags} -O3")
 set (CMAKE_Fortran_FLAGS_DEBUG "${common_flags} -O0 -g -fbacktrace -fcheck=pointer -fcheck=mem \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,7 +85,7 @@ target_link_libraries(${this} PUBLIC gftl-shared gftl)
 
 install (TARGETS pflogger EXPORT PFLOGGER DESTINATION ${dest}/lib)
 install (DIRECTORY  ${PROJECT_BINARY_DIR}/include/ DESTINATION ${dest}/include)
-install (FILES  ${CURRENT_SOURCE_DIR}/error_handling_macros.fh DESTINATION ${dest}/include)
+install (FILES  ${PROJECT_SOURCE_DIR}/src/error_handling_macros.fh DESTINATION ${dest}/include)
 install (EXPORT PFLOGGER DESTINATION "${dest}/cmake")
 
 


### PR DESCRIPTION
Test building on macOS with gfortran showed two issues:

1. Set `-ffree-line-length-none` as apparently 255 was too short
2. Fix for installing a `.fh` file