### PR TITLE
Hotfix - broken serial example

### DIFF
--- a/examples/serial/all_in_one.cfg
+++ b/examples/serial/all_in_one.cfg
@@ -20,7 +20,6 @@ handlers:
    warnings:
       class:  FileHandler
       filename: warnings.log
-      lock: mpi
       level: WARNING
       formatter: basic
 
@@ -35,7 +34,6 @@ loggers:
 
    main:
       parallel: .false.
-      comm: MPI_COMM_WORLD
       handlers: [console,warnings,errors]
       level: INFO
 

--- a/src/Formatter.F90
+++ b/src/Formatter.F90
@@ -126,7 +126,6 @@ contains
       ! Allow for Python alias:
       if (f%uses_keyword('levelName')) then
          f%fmt = replace(f%fmt, '%(levelName)', '%(level_name)')
-         print*,'fmt? ', f%fmt
       end if
 
       if (present(datefmt)) then


### PR DESCRIPTION
   - Config file was referencing MPI. Must have copied from other
     example at some point.
   - Also removed a debug print