### PR TITLE
Modified name of Pair type in gFTL maps.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 # ------------------------------------------------------------------------ #
 cmake_minimum_required (VERSION 3.8.0)
 project (PFLOGGER
-  VERSION 1.4.1
+  VERSION 1.4.2
   LANGUAGES Fortran)
 
 set (CMAKE_MODULE_PATH

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.2] - 2020-05-20
+
+### Changed
+
+- Modified name of Pair type in gFTL maps.  These are not used within
+  pFlogger outside of their host modules, but it is more consistent with
+  the latest gFTL-shared and may help anyone that tries to port with XLF.
+  
+
 ## [1.4.1] - 2020-05-01
 
 ### Added

--- a/src/MpiLock.F90
+++ b/src/MpiLock.F90
@@ -1,3 +1,6 @@
+! Based upon
+! http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.113.30&rep=rep1&type=pdf
+
 module PFL_MpiLock
    use mpi
    use PFL_AbstractLock

--- a/src/StringAbstractLoggerPolyMap.F90
+++ b/src/StringAbstractLoggerPolyMap.F90
@@ -14,11 +14,13 @@ module  PFL_StringAbstractLoggerPolyMap
 
 #define _map LoggerMap
 #define _iterator LoggerIterator
+#define _pair StringLoggerPair
 #include "types/key_deferredLengthString.inc"
 
 #define _value class(AbstractLogger)
 #define _value_allocatable
 #define _value_equal_defined
+
 
 #define _alt
 #define _pair_allocatable   

--- a/src/StringFilterMap.F90
+++ b/src/StringFilterMap.F90
@@ -12,6 +12,7 @@
 module  PFL_StringFilterMap
    use PFL_AbstractFilter
 #define _map FilterMap
+#define _pair FilterPair
 #define _iterator FilterIterator
    
 #include "types/key_deferredLengthString.inc"

--- a/src/StringFormatterMap.F90
+++ b/src/StringFormatterMap.F90
@@ -12,6 +12,7 @@
 module  PFL_StringFormatterMap
    use PFL_Formatter
 #define _map FormatterMap
+#define _pair FormatterPair
 #define _iterator FormatterIterator
    
 #include "types/key_deferredLengthString.inc"

--- a/src/StringHandlerMap.F90
+++ b/src/StringHandlerMap.F90
@@ -12,6 +12,7 @@
 module  PFL_StringHandlerMap
    use PFL_AbstractHandler
 #define _map HandlerMap
+#define _pair HandlerPair
 #define _iterator HandlerIterator
    
 #include "types/key_deferredLengthString.inc"

--- a/src/StringLockMap.F90
+++ b/src/StringLockMap.F90
@@ -12,6 +12,7 @@
 module  PFL_StringLockMap
    use PFL_AbstractLock
 #define _map LockMap
+#define _pair LockPair
 #define _iterator LockIterator
    
 #include "types/key_deferredLengthString.inc"


### PR DESCRIPTION
- Modified name of Pair type in gFTL maps.  These are not used within
  pFlogger outside of their host modules, but it is more consistent with
  the latest gFTL-shared and may help anyone that tries to port with XLF.