### PR TITLE
Hotfix/free_shared_lock

### DIFF
--- a/src/AbstractLock.F90
+++ b/src/AbstractLock.F90
@@ -10,6 +10,7 @@ module PFL_AbstractLock
       procedure(lock), deferred :: release
       procedure(lock), deferred :: init
       procedure(lock), deferred :: destroy
+      procedure(is_initialized), deferred :: is_initialized
    end type AbstractLock
 
    abstract interface
@@ -17,6 +18,11 @@ module PFL_AbstractLock
          import AbstractLock
          class (AbstractLock), intent(inout) :: this
       end subroutine lock
-   end interface
 
+      function is_initialized(this) result(init)
+         import AbstractLock
+         class (AbstractLock), intent(in) :: this
+         logical :: init
+      end function
+   end interface
 end module PFL_AbstractLock

--- a/src/FileHandler.F90
+++ b/src/FileHandler.F90
@@ -25,7 +25,7 @@ module PFL_FileHandler
       private
       logical :: is_open_ = .false.
       character(len=:), allocatable :: file_name
-      class (AbstractLock), allocatable :: lock
+      class (AbstractLock), pointer :: lock
    contains
       procedure :: is_open
       procedure :: open
@@ -254,7 +254,8 @@ contains
    logical function is_lockable(this)
       class (FileHandler), intent(in) :: this
 
-      is_lockable = allocated(this%lock)
+      is_lockable = .false.
+      if (associated(this%lock)) is_lockable = this%lock%is_initialized()
 
    end function is_lockable
 

--- a/src/MpiLock.F90
+++ b/src/MpiLock.F90
@@ -19,11 +19,13 @@ module PFL_MpiLock
       integer :: pe_locks_type
       type (c_ptr) :: locks_ptr
       logical, allocatable :: local_data(:)
+      logical :: initialized
    contains
       procedure :: acquire
       procedure :: release
       procedure :: init
       procedure :: destroy
+      procedure :: is_initialized
    end type MpiLock
 
    integer, parameter :: LOCK_TAG = 10
@@ -45,7 +47,7 @@ contains
       integer, intent(in) :: comm
 
       lock%comm = comm  ! will duplicate during init()
-
+      lock%initialized = .false.
    end function newMpiLock
 
 
@@ -100,7 +102,7 @@ contains
       end if
 
       allocate(this%local_data(this%npes-1))
-
+      this%initialized = .true.
     end subroutine init
 
 
@@ -177,6 +179,7 @@ contains
       integer :: ierror
 
       ! Release resources
+      if (.not. this%is_initialized()) return
       call MPI_Type_free(this%pe_locks_type, ierror)
       call MPI_Win_free(this%window, ierror)
 
@@ -185,9 +188,16 @@ contains
          call MPI_Free_mem(scratchpad, ierror)
       end if
 
+      this%initialized = .false.
       !W.J comment out. Does this comm belong to this lock? Maybe not
       !call MPI_Comm_free(this%comm, ierror)
 
    end subroutine destroy
+
+   function is_initialized(this) result(init)
+      class (MpiLock), intent(in) :: this
+      logical :: init
+      init = this%initialized
+   end function
 
 end module PFL_MpiLock

--- a/src/MpiLock.F90
+++ b/src/MpiLock.F90
@@ -59,6 +59,8 @@ contains
       integer(kind=MPI_ADDRESS_KIND) :: sz
       integer :: old_comm
 
+      if (this%is_initialized()) return
+      
       old_comm = this%comm
       call MPI_Comm_dup(old_comm, this%comm, ierror)
       call MPI_Comm_rank(this%comm, this%rank, ierror)


### PR DESCRIPTION
The FileHandler has a lock pointer. With shallow copy, the pointer will not be allocated again. The same FileHandler in  different loggers would share the lock which should be destroyed only once.