### PR TITLE
Add Travis CI to pFlogger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,98 @@
+os:
+   - linux
+   - osx
+
+dist: bionic
+
+osx_image: xcode11.6
+
+language: c
+
+arch:
+  - amd64
+
+addons:
+   apt:
+      sources:
+         - ubuntu-toolchain-r-test
+         - sourceline: deb https://apt.kitware.com/ubuntu/ bionic main
+           key_url: https://apt.kitware.com/keys/kitware-archive-latest.asc
+      packages:
+         - gfortran-9
+         - gfortran-10
+         - g++-9
+         - g++-10
+         - libgfortran5-dbg
+         - libxml2-utils
+         - cmake
+   homebrew:
+      packages:
+         - gcc@9
+         - cmake
+      update: false
+
+env:
+   global:
+      - MPI_NAME=openmpi
+   jobs:
+      - FC='gfortran-9' CC='gcc-9' CXX='g++-9'  MPI_VER=4.0.4 CACHE_NAME=$TRAVIS_OS_NAME-$TRAVIS_CPU_ARCH-$FC-$MPI_NAME-$MPI_VER
+      - FC='gfortran-10' CC='gcc-10' CXX='g++-10' MPI_VER=4.0.4 CACHE_NAME=$TRAVIS_OS_NAME-$TRAVIS_CPU_ARCH-$FC-$MPI_NAME-$MPI_VER
+
+# caching of the whole `local` directory. Can't cache only the one for this
+# `env`, because otherwise the different instances will overwrite the cache.
+# For the first test-run, the build has to be run sequentially (limit parallel
+# workers to 1) so that the cache can be correctly initialized. Once the cache
+# is build, parallel workers can be re-enabled.
+cache:
+   directories:
+      - ${HOME}/local
+   timeout: 600
+
+before_script:
+   # Install cmake on linux (assume osx is good)
+   - |
+      if [ $TRAVIS_OS_NAME != 'osx' ] ; then
+         export cmake_ver=3.18.1
+         sh ./tools/travis-install-cmake.sh ${cmake_ver}
+         # set up cmake location
+         export PATH=${HOME}/local/cmake/bin:${PATH}
+         export LIBRARY_PATH=${HOME}/local/cmake/lib:${LIBRARY_PATH}
+         export LD_LIBRARY_PATH=${HOME}/local/cmake/lib:${LD_LIBRARY_PATH}
+         # print out version information
+         sudo apt purge --autoremove cmake
+         cmake --version
+      else
+         cmake --version
+      fi
+   # install MPI
+   - |
+     mkdir -p ${HOME}/local
+     ls -r ${HOME}/local
+     sh ./tools/travis-install-mpi.sh ${MPI_NAME} ${MPI_VER}
+     # set up MPI location
+     export PATH=${PATH}:${HOME}/local/${MPI_NAME}/bin
+     export LIBRARY_PATH=${LIBRARY_PATH}:${HOME}/local/${MPI_NAME}/lib
+     export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${HOME}/local/${MPI_NAME}/lib
+     # print out version information
+     ${FC} --version
+     mpirun --version
+   # Install GFE dependencies
+   - bash ./tools/travis-install-gfe.bash
+   # Now build pFlogger
+   - cd ${TRAVIS_BUILD_DIR}
+   - mkdir -p build && cd build
+   - cmake .. -DCMAKE_Fortran_COMPILER=${FC} -DCMAKE_INSTALL_PREFIX=${HOME}/Software/pFlogger -DCMAKE_PREFIX_PATH=${HOME}/Software/GFE
+
+script:
+   # Build
+   - make -j$(nproc) VERBOSE=1
+   # Make tests
+   - make -j$(nproc) tests
+   # Run tests
+   - ctest -j $(nproc) --output-on-failure
+
+notifications:
+   email:
+      recipients:
+         - matthew.thompson@nasa.gov
+         - tom.clune@nasa.gov

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,4 @@
+# pFlogger/tools
+
+pFlogger/tools contains resources for use during development, build, and install, but which should not themselves be installed.
+

--- a/tools/travis-install-cmake.sh
+++ b/tools/travis-install-cmake.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+
+cmake_ver="$1"
+
+if [ ! -d "${HOME}/local/cmake/bin" ] ; then
+   wget https://github.com/Kitware/CMake/releases/download/v${cmake_ver}/cmake-${cmake_ver}.tar.gz
+   tar -xzf cmake-${cmake_ver}.tar.gz && rm cmake-${cmake_ver}.tar.gz
+   cd cmake-${cmake_ver}
+   mkdir build && cd build
+   cmake .. -DCMAKE_INSTALL_PREFIX=${HOME}/local/cmake
+   make -j$(nproc)
+   make install/strip
+   cd ../.. && rm -r cmake-${cmake_ver}
+fi

--- a/tools/travis-install-gfe.bash
+++ b/tools/travis-install-gfe.bash
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+GFE_DIR=${HOME}/gfe
+mkdir -p ${GFE_DIR}
+
+# First install prerequisites
+GFE_INSTALL_DIR=${HOME}/Software/GFE
+mkdir -p ${GFE_INSTALL_DIR}
+
+to_build=(gFTL gFTL-shared fArgParse yaFyaml pFUnit)
+for repo in "${to_build[@]}"
+do
+   cd ${GFE_DIR}
+   git clone https://github.com/Goddard-Fortran-Ecosystem/${repo}.git
+   cd ${GFE_DIR}/${repo}
+   mkdir build && cd build
+   cmake .. -DCMAKE_INSTALL_PREFIX=${GFE_INSTALL_DIR} -DCMAKE_PREFIX_PATH=${GFE_INSTALL_DIR}
+   make -j$(nproc) install
+done
+

--- a/tools/travis-install-mpi.sh
+++ b/tools/travis-install-mpi.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# source: mpi4py
+# https://github.com/mpi4py/mpi4py/blob/master/conf/travis/install-mpi.sh
+
+set -e
+
+MPI_IMPL="$1"
+MPI_VER="$2"
+os=`uname`
+
+if [ ! -d "${HOME}/local/${MPI_IMPL}/bin" ]
+then
+   mkdir -p ${HOME}/MPI/src/openmpi && cd ${HOME}/MPI/src/openmpi
+   wget --no-check-certificate https://download.open-mpi.org/release/open-mpi/v${MPI_VER%.*}/${MPI_IMPL}-${MPI_VER}.tar.bz2
+   tar xjf ${MPI_IMPL}-${MPI_VER}.tar.bz2 && rm ${MPI_IMPL}-${MPI_VER}.tar.bz2
+   cd ${MPI_IMPL}-${MPI_VER}
+   ./configure --prefix=${HOME}/local/${MPI_IMPL} --disable-wrapper-rpath --disable-wrapper-runpath
+   make -j $(nproc)
+   make install-strip
+   cd .. && rm -r ${MPI_IMPL}-${MPI_VER}
+   exit 0
+else
+   echo "Using cached ${MPI_IMPL} directory";
+   exit 0
+fi


### PR DESCRIPTION
This adds Travis CI to pFlogger. Tests are on Ubuntu 18 and very recent macOS to avoid expensive `brew update` call.