### PR TITLE
Fixed ability to embed pFlogger alongside other GFE libraries in a superproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ project (PFLOGGER
   LANGUAGES Fortran)
 
 set (CMAKE_MODULE_PATH
-   ${CMAKE_SOURCE_DIR}/cmake
+   ${PROJECT_SOURCE_DIR}/cmake
 )
 
 include (PreventInSourceBuild)
@@ -33,9 +33,15 @@ include (DefinePlatformDefaults)
 
 set (CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-find_package (GFTL REQUIRED)
-find_package (GFTL_SHARED REQUIRED)
-find_package (YAFYAML REQUIRED)
+if (NOT TARGET GFTL::gftl)
+  find_package (GFTL REQUIRED)
+endif ()
+if (NOT TARGET GFTL_SHARED::gftl-shared)
+  find_package (GFTL_SHARED REQUIRED)
+endif ()
+if (NOT TARGET YAFYAML::yafyaml)
+  find_package (YAFYAML REQUIRED)
+endif ()
 
 find_package (MPI QUIET)
 find_package (PFUNIT QUIET)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ability to embed pFlogger alongside the other GFE libraries in a superproject.
+
 ## [1.5.0] - 2021-03-15
 
 ### Added


### PR DESCRIPTION
re: https://github.com/Goddard-Fortran-Ecosystem/fArgParse/pull/84