### PR TITLE
build a pflogger stub lib

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,107 +3,117 @@
 get_filename_component(DIRNAME "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
 set(this pflogger)
 
-set(SRCS
-   ArgListUtilities.F90
-   AbstractFilter.F90
-   AbstractLogger.F90
-   AbstractLock.F90
-   Config.F90
-   DynamicBuffer.F90
-   Exception.F90
-   Filter.F90
-   Filterer.F90
-   FastFormatter.F90
-   FormatToken.F90
-   FormatParser.F90
-   FormatString.F90
-   Formatter.F90
-   KeywordEnforcer.F90
-   LevelFilter.F90
-   LogRecord.F90
-   Logger.F90
-   LoggerManager.F90
-   Object.F90
-   pflogger.F90
-   RootLogger.F90
-   SeverityLevels.F90
-   AbstractHandler.F90
-   StreamHandler.F90
-   FileHandler.F90
-   RotatingFileHandler.F90
-   StringUtilities.F90
-   WrapArray.F90
-# FTL containers
-   StringAbstractLoggerPolyMap.F90
-   StringFormatterMap.F90
-   StringFilterMap.F90
-   StringHandlerMap.F90
-   StringLockMap.F90
-   LoggerPolyVector.F90
-   AbstractHandlerPolyVector.F90
-   AbstractHandlerPtrVector.F90
-   AbstractFilterPolyVector.F90
-   FormatTokenVector.F90
-)
+option(WITH_PFLOGGER "Build pflogger library" ON)
 
-if (MPI_FOUND) 
-  list (APPEND SRCS
-     MpiFilter.F90
-     MpiFormatter.F90
-     MpiCommConfig.F90
-     )
-   if (SUPPORT_FOR_MPI_ALLOC_MEM_CPTR)
-     list (APPEND SRCS MpiLock.F90)
-   endif ()
-
-endif ()
-
-set (bin ${CMAKE_CURRENT_BINARY_DIR} )
-set (src ${CMAKE_CURRENT_SOURCE_DIR} )
-
-
-add_library (${this} STATIC ${SRCS})
-add_library(PFLOGGER::pflogger ALIAS pflogger)
-target_link_libraries (${this} PUBLIC YAFYAML::yafyaml)
-set_target_properties(${this} PROPERTIES Fortran_MODULE_DIRECTORY ${PFLOGGER_BINARY_DIR}/include)
-
-
-
-if (MPI_FOUND)
-  target_link_libraries (${this} PRIVATE
-    $<INSTALL_INTERFACE:MPI::MPI_Fortran>)
-  target_compile_definitions(${this} PRIVATE _LOGGER_USE_MPI)
-endif ()
-
-
-if (MPI_FOUND)
-  if (PFUNIT_FOUND)
-    add_library (mock-mpi MockMpi.F90)
-    set_target_properties(mock-mpi PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mock-mpi)
-    target_include_directories (mock-mpi PUBLIC ${MPI_Fortran_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR}/mock-mpi)
-    target_include_directories (mock-mpi PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
-    target_link_libraries (mock-mpi PUBLIC PFUNIT::funit)
-    if (SUPPORT_FOR_C_LOC_ASSUMED_SIZE)
-      target_compile_definitions(mock-mpi PRIVATE -DSUPPORT_FOR_C_LOC_ASSUMED_SIZE)
-    endif ()
-
-    # Complex linkage depending on target:
-    set(isTest $<STREQUAL:$<TARGET_PROPERTY:IS_TEST>,1>)
-    set(notTest $<NOT:${isTest}>)
-
-    target_link_libraries (pflogger PUBLIC
-#      $<BUILD_INTERFACE:mock-mpi>
-      $<${notTest}:MPI::MPI_Fortran>
-      $<${isTest}:mock-mpi>
-      $<${isTest}:PFUNIT::funit>)
-
-  else ()
-    target_link_libraries (pflogger PRIVATE MPI::MPI_Fortran)
+if (WITH_PFLOGGER) 
+  set(SRCS
+     ArgListUtilities.F90
+     AbstractFilter.F90
+     AbstractLogger.F90
+     AbstractLock.F90
+     Config.F90
+     DynamicBuffer.F90
+     Exception.F90
+     Filter.F90
+     Filterer.F90
+     FastFormatter.F90
+     FormatToken.F90
+     FormatParser.F90
+     FormatString.F90
+     Formatter.F90
+     KeywordEnforcer.F90
+     LevelFilter.F90
+     LogRecord.F90
+     Logger.F90
+     LoggerManager.F90
+     Object.F90
+     pflogger.F90
+     RootLogger.F90
+     SeverityLevels.F90
+     AbstractHandler.F90
+     StreamHandler.F90
+     FileHandler.F90
+     RotatingFileHandler.F90
+     StringUtilities.F90
+     WrapArray.F90
+  # FTL containers
+     StringAbstractLoggerPolyMap.F90
+     StringFormatterMap.F90
+     StringFilterMap.F90
+     StringHandlerMap.F90
+     StringLockMap.F90
+     LoggerPolyVector.F90
+     AbstractHandlerPolyVector.F90
+     AbstractHandlerPtrVector.F90
+     AbstractFilterPolyVector.F90
+     FormatTokenVector.F90
+  )
+  
+  if (MPI_FOUND) 
+    list (APPEND SRCS
+       MpiFilter.F90
+       MpiFormatter.F90
+       MpiCommConfig.F90
+       )
+     if (SUPPORT_FOR_MPI_ALLOC_MEM_CPTR)
+       list (APPEND SRCS MpiLock.F90)
+     endif ()
+  
   endif ()
   
-endif()
+  set (bin ${CMAKE_CURRENT_BINARY_DIR} )
+  set (src ${CMAKE_CURRENT_SOURCE_DIR} )
+  
+  
+  add_library (${this} STATIC ${SRCS})
+  add_library(PFLOGGER::pflogger ALIAS pflogger)
+  target_link_libraries (${this} PUBLIC YAFYAML::yafyaml)
+  set_target_properties(${this} PROPERTIES Fortran_MODULE_DIRECTORY ${PFLOGGER_BINARY_DIR}/include)
+  
+  
+  
+  if (MPI_FOUND)
+    target_link_libraries (${this} PRIVATE
+      $<INSTALL_INTERFACE:MPI::MPI_Fortran>)
+    target_compile_definitions(${this} PRIVATE _LOGGER_USE_MPI)
+  endif ()
+  
+  
+  if (MPI_FOUND)
+    if (PFUNIT_FOUND)
+      add_library (mock-mpi MockMpi.F90)
+      set_target_properties(mock-mpi PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mock-mpi)
+      target_include_directories (mock-mpi PUBLIC ${MPI_Fortran_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR}/mock-mpi)
+      target_include_directories (mock-mpi PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+      target_link_libraries (mock-mpi PUBLIC PFUNIT::funit)
+      if (SUPPORT_FOR_C_LOC_ASSUMED_SIZE)
+        target_compile_definitions(mock-mpi PRIVATE -DSUPPORT_FOR_C_LOC_ASSUMED_SIZE)
+      endif ()
+  
+      # Complex linkage depending on target:
+      set(isTest $<STREQUAL:$<TARGET_PROPERTY:IS_TEST>,1>)
+      set(notTest $<NOT:${isTest}>)
+  
+      target_link_libraries (pflogger PUBLIC
+  #      $<BUILD_INTERFACE:mock-mpi>
+        $<${notTest}:MPI::MPI_Fortran>
+        $<${isTest}:mock-mpi>
+        $<${isTest}:PFUNIT::funit>)
+  
+    else ()
+      target_link_libraries (pflogger PRIVATE MPI::MPI_Fortran)
+    endif ()
+    
+  endif()
 
-
+else () # build empty pflogger_stub
+  set(SRCS
+     WrapArray.F90
+     pflogger_stub.F90
+     )
+  add_library (${this} STATIC ${SRCS})
+  add_library(PFLOGGER::pflogger ALIAS pflogger)
+endif ()
   
 set (dest "PFLOGGER-${PFLOGGER_VERSION_MAJOR}.${PFLOGGER_VERSION_MINOR}")
 
@@ -118,7 +128,3 @@ target_link_libraries(${this} PUBLIC GFTL_SHARED::gftl-shared GFTL::gftl)
 install (TARGETS pflogger EXPORT PFLOGGER DESTINATION ${dest}/lib)
 install (DIRECTORY  ${PROJECT_BINARY_DIR}/include/ DESTINATION ${dest}/include)
 install (FILES  ${PROJECT_SOURCE_DIR}/src/error_handling_macros.fh DESTINATION ${dest}/include)
-
-
-
-

--- a/src/pflogger_stub.F90
+++ b/src/pflogger_stub.F90
@@ -1,0 +1,192 @@
+#include "error_handling_macros.fh"
+module PFL_Logger
+   use gFTL_StringUnlimitedMap
+   use PFL_KeywordEnforcer
+   implicit none
+   private
+
+   public :: Logger
+
+   public :: NOTSET
+   public :: DEBUG_LEVEL
+   public :: INFO_LEVEL
+   public :: WARNING_LEVEL
+   public :: ERROR_LEVEL
+   public :: CRITICAL_LEVEL
+
+   enum, bind(c)
+      enumerator :: &
+           & NOTSET   =  0, &
+           & DEBUG_LEVEL    = 10, &
+           & INFO_LEVEL     = 20, &
+           & WARNING_LEVEL  = 30, &
+           & ERROR_LEVEL    = 40, &
+           & CRITICAL_LEVEL = 50
+   end enum
+
+   type :: Logger
+   contains
+      procedure :: debug
+      procedure :: info
+      procedure :: warning
+      procedure :: error
+      procedure :: critical
+      procedure :: free
+   end type Logger
+
+#define ARG_LIST arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9
+
+contains
+
+   subroutine free(this)
+      class (Logger), intent(inout) :: this
+   end subroutine free
+
+   subroutine debug(this, message, ARG_LIST, unusable, extra, line, file, rc)
+      class (Logger), target, intent(inout) :: this
+      character(len=*), intent(in) :: message
+      include 'recordOptArgs.inc'  
+      class (KeywordEnforcer), optional, intent(in) :: unusable
+      type (StringUnlimitedMap), optional, target, intent(in) :: extra
+      integer, optional, intent(in) :: line
+      character(*), optional, intent(in) :: file
+      integer, optional, intent(out) :: rc
+      _RETURN(_SUCCESS,rc)
+   end subroutine debug
+
+   subroutine info(this, message, ARG_LIST, unusable, extra, line, file, rc)
+      class (Logger), target, intent(inout) :: this
+      character(len=*), intent(in) :: message
+      include 'recordOptArgs.inc'  
+      class (KeywordEnforcer), optional, intent(in) :: unusable
+      type (StringUnlimitedMap), optional, target, intent(in) :: extra
+      integer, optional, intent(in) :: line
+      character(*), optional, intent(in) :: file
+      integer, optional, intent(out) :: rc
+      _RETURN(_SUCCESS,rc)
+   end subroutine info
+
+   subroutine warning(this, message, ARG_LIST, unusable, extra, line, file, rc)
+      class (Logger), target, intent(inout) :: this
+      character(len=*), intent(in) :: message
+      include 'recordOptArgs.inc'  
+      class (KeywordEnforcer), optional, intent(in) :: unusable
+      type (StringUnlimitedMap), optional, target, intent(in) :: extra
+      integer, optional, intent(in) :: line
+      character(*), optional, intent(in) :: file
+      integer, optional, intent(out) :: rc
+      
+      _RETURN(_SUCCESS,rc)
+
+   end subroutine warning
+
+   subroutine error(this, message, ARG_LIST, unusable, extra, line, file, rc)
+      ! Log message with the integer severity 'DEBUG'.
+      class (Logger), target, intent(inout) :: this
+      character(len=*), intent(in) :: message
+      include 'recordOptArgs.inc'  
+      class (KeywordEnforcer), optional, intent(in) :: unusable
+      type (StringUnlimitedMap), optional, target, intent(in) :: extra
+      integer, optional, intent(in) :: line
+      character(*), optional, intent(in) :: file
+      integer, optional, intent(out) :: rc
+
+      _RETURN(_SUCCESS,rc)
+
+   end subroutine error
+
+   subroutine critical(this, message, ARG_LIST, unusable, extra, line, file, rc)
+      class (Logger), target, intent(inout) :: this
+      character(len=*), intent(in) :: message
+      include 'recordOptArgs.inc'  
+      class (KeywordEnforcer), optional, intent(in) :: unusable
+      type (StringUnlimitedMap), optional, target, intent(in) :: extra
+      integer, optional, intent(in) :: line
+      character(*), optional, intent(in) :: file
+      integer, optional, intent(out) :: rc
+      _RETURN(_SUCCESS,rc)
+   end subroutine critical
+end module PFL_Logger
+
+module PFL_LoggerManager
+   use gFTL_StringUnlimitedMap
+   use PFL_Logger, only: Logger
+   implicit none
+   private
+
+   public :: logging ! singleton instance
+
+   type :: LoggerManager
+      private
+      type(Logger) :: log_
+   contains
+      procedure :: get_logger_name
+      procedure :: get_logger_root
+      generic :: get_logger => get_logger_name
+      generic :: get_logger => get_logger_root
+      procedure :: free
+   end type LoggerManager
+   
+   type (LoggerManager), target, save :: logging
+
+contains
+
+   function get_logger_root(this, rc) result(lgr)
+      class (Logger), pointer :: lgr
+      class (LoggerManager), target, intent(inout) :: this
+      integer, optional, intent(out) :: rc
+      lgr => this%log_
+      _RETURN(_SUCCESS,rc)
+   end function get_logger_root
+
+   function get_logger_name(this, name, rc) result(lgr)
+      class (Logger), pointer :: lgr
+      class (LoggerManager), target, intent(inout) :: this
+      character(len=*), intent(in) :: name
+      integer, optional, intent(out) :: rc
+      lgr => this%log_
+      _RETURN(_SUCCESS,rc)
+   end function get_logger_name
+
+   subroutine free(this)
+      class(LoggerManager), intent(inout) :: this
+   end subroutine free
+
+end module PFL_LoggerManager
+
+module pflogger
+   implicit none
+   use PFL_Logger
+   use PFL_LoggerManager
+   use PFL_WrapArray
+   private
+
+   public :: initialize
+   public :: finalize
+
+   public :: logging
+   public :: Logger
+   public :: WrapArray
+
+   public :: NOTSET
+   public :: DEBUG
+   public :: INFO
+   public :: WARNING
+   public :: ERROR
+   public :: CRITICAL
+
+contains
+   subroutine initialize(unusable, comm, logging_config, logger_name, rc)
+      class (KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(in) :: comm
+      character(len=*), optional,intent(in) :: logging_config
+      character(len=*), optional,intent(in) :: logger_name
+      integer, optional, intent(out) :: rc
+      _UNUSED_DUMMY(unusable)
+      _RETURN(_SUCCESS)
+   end subroutine initialize
+
+   subroutine finalize()
+   end subroutine finalize
+
+end module pflogger


### PR DESCRIPTION
We can build an empty pflogger library if WITH_PFLOGGER is off.   The MAPL will keep the same. However, there is another choice by moving pflogger_stub.F90 , WrapArray.F90 and relative .h file to MAPL. The option   WITH_PFLOGGER can be turned on or off in MAPL.