### PR TITLE
Add NVHPC Support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `NVHPC.cmake` and `PGI.cmake` files for NVHPC support
+
 ## [1.6.0] - 2021-09-28xs
 
 ### Changed

--- a/cmake/NVHPC.cmake
+++ b/cmake/NVHPC.cmake
@@ -1,0 +1,10 @@
+# Compiler specific flags for PGI Fortran compiler
+# (or is this now NVIDIA?)
+
+set(traceback "-traceback")
+set(check_all "-Mbounds -Mchkstk")
+
+set(CMAKE_Fortran_FLAGS_DEBUG  "-O0")
+set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+set(CMAKE_Fortran_FLAGS "-g ${traceback} ${check_all} -Mallocatable=03")
+

--- a/cmake/PGI.cmake
+++ b/cmake/PGI.cmake
@@ -1,0 +1,10 @@
+# Compiler specific flags for PGI Fortran compiler
+# (or is this now NVIDIA?)
+
+set(traceback "-traceback")
+set(check_all "-Mbounds -Mchkstk")
+
+set(CMAKE_Fortran_FLAGS_DEBUG  "-O0")
+set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+set(CMAKE_Fortran_FLAGS "-g ${traceback} ${check_all} -Mallocatable=03")
+


### PR DESCRIPTION
This PR adds an `NVHPC.cmake` and `PGI.cmake` file identical to that used in pFUnit