### PR TITLE
Add preliminary Intel LLVM Support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `IntelLLVM.cmake` file as a copy of `Intel.cmake` to support the LLVM Intel compiler frontends
+
 ## [1.9.1] - 2022-05-31
 
 ### Changed

--- a/cmake/IntelLLVM.cmake
+++ b/cmake/IntelLLVM.cmake
@@ -1,0 +1,6 @@
+set (FPP_FLAG "-cpp")
+set (SUPPRESS_LINE_LENGTH_WARNING "-diag-disable 5268")
+set (CMAKE_Fortran_FLAGS_RELEASE "${FPP_FLAG} -O3 -free -stand f08 ${SUPPRESS_LINE_LENGTH_WARNING}")
+set (CMAKE_Fortran_FLAGS_DEBUG   "${FPP_FLAG} -O0 -g -traceback \
+      -check uninit -free -stand f08 -save-temps ${SUPPRESS_LINE_LENGTH_WARNING}")
+


### PR DESCRIPTION
This PR adds preliminary `ifx` support by copying `cmake/Intel.cmake` to `cmake/IntelLLVM.cmake`. As noted by [Intel's porting guide](https://www.intel.com/content/www/us/en/developer/articles/guide/porting-guide-for-ifort-to-ifx.html), there are some flags changed or removed from `ifx` (compared to `ifort`), but they are usually a bit more advanced compared to flags used here.

One thing that might need to change is any macros (like `_INTEL`) as we might need different ones for `ifx`. There might also be workarounds/changes needed as seen in https://github.com/Goddard-Fortran-Ecosystem/pFUnit/pull/404

Keeping PR draft until `ifx` can be tested by us. 