### PR TITLE
Fix for Intel 2021.7

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Package was incorrectly assuming that all extant compilers support
   128 bit reals.  Now a check is performed to optionally include
   support for 128 bit reals.
+- Fix `Parser()` declaration for Intel 2021.7
 
 ## [1.9.2] - 2023-01-23
 

--- a/src/LoggerManager.F90
+++ b/src/LoggerManager.F90
@@ -327,7 +327,7 @@ contains
          call extra_%insert('_GLOBAL_COMMUNICATOR',comm)
       end if
 
-      p = Parser('Core')
+      p = Parser()
       c = p%load(file_name)
 
       call this%load_config(c, extra=extra_, comm=comm, rc=status)


### PR DESCRIPTION
Fix for Intel 2021.7 issue where:

```
p = Parser('Core')
```

caused an issue. (@tclune might be able to explain better 😄 )