### PR TITLE
Add uninit flag for ifx

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Workarounds for MPICH C_LOC missing interface (https://github.com/pmodels/mpich/issues/6691)
+- Add `-check nouninit` for Intel LLVM to work around [`ifx` bug](https://github.com/HPC-Bugs/reproducers/tree/main/compiler/Fortran/ifx/allocatable).
 
 ## [1.10.0] - 2023-04-17
 

--- a/cmake/IntelLLVM.cmake
+++ b/cmake/IntelLLVM.cmake
@@ -2,5 +2,5 @@ set (FPP_FLAG "-cpp")
 set (SUPPRESS_LINE_LENGTH_WARNING "-diag-disable 5268")
 set (CMAKE_Fortran_FLAGS_RELEASE "${FPP_FLAG} -O3 -free -stand f08 ${SUPPRESS_LINE_LENGTH_WARNING}")
 set (CMAKE_Fortran_FLAGS_DEBUG   "${FPP_FLAG} -O0 -g -traceback \
-      -check uninit -free -stand f08 -save-temps ${SUPPRESS_LINE_LENGTH_WARNING}")
+      -check nouninit -free -stand f08 -save-temps ${SUPPRESS_LINE_LENGTH_WARNING}")
 


### PR DESCRIPTION
This PR adds the `-check uninit` flag for `ifx` as there is currently a bug with this (see https://github.com/HPC-Bugs/reproducers/tree/main/compiler/Fortran/ifx/allocatable)