### PR TITLE
Fixes #106. Add ENABLE_MPI option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,10 @@ if (NOT TARGET YAFYAML::yafyaml)
   find_package (YAFYAML REQUIRED VERSION 1.1.0)
 endif ()
 
-find_package (MPI QUIET)
+option (ENABLE_MPI "Enable MPI support" ON)
+if (ENABLE_MPI)
+  find_package (MPI QUIET)
+endif ()
 find_package (PFUNIT QUIET)
 
 #-----------------------------------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add new `ENABLE_MPI` option to allow disabling MPI support (#106). By default, MPI is enabled to maintain backward compatibility.
+
 ## [1.11.0] - 2023-11-29
 
 ### Fixed


### PR DESCRIPTION
Closes #106 

This PR adds an `ENABLE_MPI` option to pFlogger which defaults to `ON` to preserve old behavior. With it set to `OFF` pFlogger will not even look for MPI.