### PR TITLE
Add quiet flag for NAG Fortran

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+### Changed
+
+- Added `-quiet` flag for NAG Fortran
 
 ## [1.13.1] - 2024-03-07
 

--- a/cmake/NAG.cmake
+++ b/cmake/NAG.cmake
@@ -1,6 +1,6 @@
 set (FPP_FLAG "${FPP_FLAG} -fpp")
-   
+
 # set (CMAKE_Fortran_FLAGS_DEBUG   "${FPP_FLAG} -O0 -gline -C=all")
 # workaround for nag 6.2
-set (CMAKE_Fortran_FLAGS_DEBUG "-C=array -C=alias -C=bits -C=calls -C=do -C=intovf -C=present -C=pointer -O0")
-set (CMAKE_Fortran_FLAGS_RELEASE "${FPP_FLAG} -O3")
+set (CMAKE_Fortran_FLAGS_DEBUG "-quiet -C=array -C=alias -C=bits -C=calls -C=do -C=intovf -C=present -C=pointer -O0")
+set (CMAKE_Fortran_FLAGS_RELEASE "-quiet ${FPP_FLAG} -O3")


### PR DESCRIPTION
This PR adds `-quiet` to the NAG Fortran compiler flags. This flag will "[s]uppress the compiler banner and the summary line, so that only diagnostic messages will appear."