### PR TITLE
Workaround another polymorphic assignment bug in gfortran 13.2

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Workaround additional polymorphic assignment bug in gfortran 13.2 (in build_locks)
+
 ## [1.13.2] - 2024-03-13
 
 ### Fixed


### PR DESCRIPTION
This PR has another workaround for a polymorphic assignment bug with GCC 13. This time in `build_locks`.

NOTE: My editor cleaned up some whitespace. So ["Hide whitespace" to see the changes](https://github.com/Goddard-Fortran-Ecosystem/pFlogger/pull/123/files?diff=split&w=1).