### PR TITLE
Preliminary LLVMFlang Support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,19 +16,19 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
-        compiler: [gfortran-11, gfortran-12, gfortran-13]
-        # gfortran-10 is only on ubuntu-22.04
-        # gfortran-14 is available on ubuntu-24.04
+        compiler: [gfortran-12, gfortran-13, gfortran-14]
+        # gfortran-10 and -11 are only on ubuntu-22.04
+        # gfortran-13 and -14 are not on ubuntu-22.04
         include:
           - os: ubuntu-22.04
             compiler: gfortran-10
-          - os: ubuntu-24.04
-            compiler: gfortran-14
-        exclude:
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             compiler: gfortran-11
+        exclude:
           - os: ubuntu-22.04
             compiler: gfortran-13
+          - os: ubuntu-22.04
+            compiler: gfortran-14
 
       # fail-fast if set to 'true' here is good for production, but when
       # debugging, set to 'false'. fail-fast means if *any* ci test in the matrix fails

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,8 +169,8 @@ jobs:
             build/**/*.log
 
   Nvidia:
-    runs-on: ubuntu-20.04
-    container: nvcr.io/nvidia/nvhpc:24.1-devel-cuda12.3-ubuntu22.04
+    runs-on: ubuntu-24.04
+    container: nvcr.io/nvidia/nvhpc:24.7-devel-cuda12.5-ubuntu24.04
     env:
       FC: nvfortran
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
             build/**/*.log
 
   Intel:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     env:
       FC: ifx
@@ -169,8 +169,8 @@ jobs:
             build/**/*.log
 
   Nvidia:
-    runs-on: ubuntu-24.04
-    container: nvcr.io/nvidia/nvhpc:24.7-devel-cuda12.5-ubuntu24.04
+    runs-on: ubuntu-22.04
+    container: nvcr.io/nvidia/nvhpc:24.7-devel-cuda12.5-ubuntu22.04
     env:
       FC: nvfortran
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,12 @@ if (PFUNIT_FOUND)
   if (NOT TARGET tests)
     add_custom_target(tests COMMAND ${CMAKE_CTEST_COMMAND})
   endif ()
-   add_subdirectory(tests EXCLUDE_FROM_ALL)
+  # We found issues between LLVMFlang, tests, and MPI. Until
+  # this can be more fully explored, for now do not run the tests
+  # with LLVMFlang.
+  if (NOT CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang")
+    add_subdirectory(tests EXCLUDE_FROM_ALL)
+  endif ()
 endif()
 
 add_subdirectory(examples EXCLUDE_FROM_ALL)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - LLVMFlang compiler support
+  - NOTE: Issues between LLVMFlang, MPI, and linktime mocking means for now the tests are not built with LLVMFlang
 
 ### Changed
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update CI to remove `macos-12`, add `macos-14` and `ubuntu-24.04`
+- Update CI to have `gfortran-10` and `gfortran-11` only on `ubuntu-22.04`
+- Update CI NVIDIA to NVHPC 24.7
 
 ## [1.15.0] - 2024-05-17
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- LLVMFlang compiler support
+
 ## [1.14.0] - 2024-03-26
 
 ### Fixed

--- a/cmake/LLVMFlang.cmake
+++ b/cmake/LLVMFlang.cmake
@@ -1,0 +1,7 @@
+# Compiler specific flags for LLVM Flang
+
+set(cpp "-cpp")
+
+set(common_flags "${cpp}")
+set(CMAKE_Fortran_FLAGS_DEBUG  "-O0 -g ${common_flags}")
+set(CMAKE_Fortran_FLAGS_RELEASE "-O3 ${common_flags}")


### PR DESCRIPTION
This PR adds preliminary support for the `LLVMFlang` compiler. At the moment,
there are still issues with testing, etc.