### PR TITLE
Move from spread to reshape in MockMPI

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change use of `spread` in `MockMPI.F90` initialization to `reshape` to avoid NVHPC issue
+
 ## [1.14.0] - 2024-03-26
 
 ### Changed

--- a/src/MockMpi.F90
+++ b/src/MockMpi.F90
@@ -20,7 +20,7 @@ module mpi
 
    integer, parameter :: MPI_ADDRESS_KIND = INT64
    integer, parameter :: MPI_STATUS_SIZE = 6
-   integer, parameter :: MPI_STATUS_IGNORE(MPI_STATUS_SIZE) = spread(0, dim=1, ncopies=MPI_STATUS_SIZE)
+   integer, parameter :: MPI_STATUS_IGNORE(MPI_STATUS_SIZE) = reshape([0], shape=[MPI_STATUS_SIZE], pad=[0])
    integer, parameter :: MPI_LOGICAL = 9
    integer, parameter :: MPI_SUCCESS = 0
    integer, parameter :: MPI_INFO_NULL = 0


### PR DESCRIPTION
Per NVIDIA:

> I was finally able to reproduce the issue with MockMpi.F90.  As the error message indicates, nvfortran does not support spread as a data initializer. Unfortunately, it is not trivial to add spread as a data initializer for nvfortran. Please suggest the following work around to the customer...

This PR changes the `spread` call to use `reshape` as @tclune believes it should be acceptable by other compilers.