### PR TITLE
Add Flang to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -224,3 +224,59 @@ jobs:
           path: |
             build/**/*.log
 
+  Flang:
+    runs-on: ubuntu-latest
+    container: gmao/llvm-flang:latest
+    env:
+      FC: flang-new
+
+    name: Flang
+    steps:
+      - name: Versions
+        run: |
+          ${FC} --version
+          cmake --version
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set all directories as git safe
+        run: |
+          git config --global --add safe.directory '*'
+
+      - name: Add python-is-python3 package
+        run: |
+          apt-get update
+          apt-get install -y python-is-python3
+
+      - name: Build GFE Prereqs
+        run: |
+          bash ./tools/ci-install-gfe.bash
+
+      - name: Build pFlogger
+        run: |
+          mkdir -p build
+          cd build
+          cmake .. -DCMAKE_Fortran_COMPILER=${FC} -DCMAKE_INSTALL_PREFIX=${HOME}/Software/pFlogger -DCMAKE_PREFIX_PATH=${HOME}/Software/GFE
+          make -j4
+
+      - name: Build Tests
+        run: |
+          cd build
+          make -j4 tests
+
+      - name: Run Tests
+        run: |
+          cd build
+          ctest -j1 --output-on-failure --repeat until-pass:4
+
+      - name: Archive log files on failure
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: logfiles
+          path: |
+            build/**/*.log
+

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Modified CMake logic to build entirely separate library (pflogger-with-mock) to support testing with mocks. Previous cheat to link pflogger against real MPI for runs but mock MPI for tests did not work with LLVM.   Seems to be due to some encryption type protection on module info.
 - Update CI to have `gfortran-10` and `gfortran-11` only on `ubuntu-22.04`
 - Update CI NVIDIA to NVHPC 24.7
+- Add Flang to CI
 
 ## [1.15.0] - 2024-05-17
 


### PR DESCRIPTION
This PR adds a Flang build to the CI tests. This uses a new Flang docker image built at https://github.com/GEOS-ESM/build-llvm-flang