### PR TITLE
Revert use of c_bool in MpiLock.F90

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 # ------------------------------------------------------------------------ #
 cmake_minimum_required (VERSION 3.12)
 project (PFLOGGER
-  VERSION 1.16.0
+  VERSION 1.16.1
   LANGUAGES Fortran)
 
 set (CMAKE_MODULE_PATH

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.1] - 2025-02-06
+
+### Fixed
+
+- Reverted use of `c_bool` in `MpiLock.F90`. Was causing issues with some compiler/MPI combinations.
+
 ## [1.16.0] - 2025-02-03
 
 ### Added

--- a/src/MpiLock.F90
+++ b/src/MpiLock.F90
@@ -6,7 +6,7 @@ module PFL_MpiLock
    use PFL_Exception
    use PFL_AbstractLock
    use iso_fortran_env, only: INT64
-   use iso_c_binding, only: c_ptr, c_f_pointer, c_bool
+   use iso_c_binding, only: c_ptr, c_f_pointer
    implicit none
    private
 
@@ -90,7 +90,7 @@ contains
       if (this%rank == 0) then
 
          block
-           logical(kind=C_BOOL), pointer :: scratchpad(:)
+           logical, pointer :: scratchpad(:)
            integer :: sizeof_logical
 
            call MPI_Type_extent(MPI_LOGICAL, sizeof_logical, status)
@@ -210,7 +210,7 @@ contains
       class (MpiLock), intent(inout) :: this
       integer, optional, intent(out) :: rc
 
-      logical(kind=C_BOOL), pointer :: scratchpad(:)
+      logical, pointer :: scratchpad(:)
       integer :: status
 
       ! Release resources


### PR DESCRIPTION
Testing of pFlogger and MAPL showed an issue in `MpiLock.F90` with `c_bool`. For now we revert back to how it was in v1.15.0 and will investigate further.