### PR TITLE
Update CMake minimum version to 3.24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
         compiler: [gfortran-12, gfortran-13, gfortran-14]
         # gfortran-10 and -11 are only on ubuntu-22.04
         # gfortran-13 and -14 are not on ubuntu-22.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 # environment.
 #
 # ------------------------------------------------------------------------ #
-cmake_minimum_required (VERSION 3.12)
+cmake_minimum_required (VERSION 3.24)
 project (PFLOGGER
   VERSION 1.16.1
   LANGUAGES Fortran)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update CMake minimum version to 3.24
+- Update CI to use `macos-15`, remove `macos-13`
 
 ## [1.16.1] - 2025-02-06
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update CMake minimum version to 3.24
+
 ## [1.16.1] - 2025-02-06
 
 ### Fixed


### PR DESCRIPTION
This PR updates the CMake minimum version to 3.24. We choose this as internal use of GFE with MAPL uses 3.24 so we update here for consistency.