### PR TITLE
Fixes for ifx 2025.2 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
-        compiler: [gfortran-12, gfortran-13, gfortran-14]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
+        compiler: [gfortran-12, gfortran-13, gfortran-14, gfortran-15]
         # gfortran-10 and -11 are only on ubuntu-22.04
-        # gfortran-13 and -14 are not on ubuntu-22.04
+        # gfortran-13 and -14 and -15 are not on ubuntu-22.04
+        # gfortran-15 is only on macos
         include:
           - os: ubuntu-22.04
             compiler: gfortran-10
@@ -29,6 +30,10 @@ jobs:
             compiler: gfortran-13
           - os: ubuntu-22.04
             compiler: gfortran-14
+          - os: ubuntu-22.04
+            compiler: gfortran-15
+          - os: ubuntu-24.04
+            compiler: gfortran-15
 
       # fail-fast if set to 'true' here is good for production, but when
       # debugging, set to 'false'. fail-fast means if *any* ci test in the matrix fails

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Workaround for `ifx` 2025.2 preprocessor bug
 
+### Changed
+
+- Remove `macos-13` from CI, add `macos-15`
+- Add `gfortran-15` to macOS CI
+
 ## [1.16.1] - 2025-02-06
 
 ### Fixed

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Workaround for `ifx` 2025.2 preprocessor bug
+
 ## [1.16.1] - 2025-02-06
 
 ### Fixed

--- a/cmake/IntelLLVM.cmake
+++ b/cmake/IntelLLVM.cmake
@@ -1,6 +1,38 @@
-set (FPP_FLAG "-cpp")
+set(cpp "-cpp") # default for all other versions
+if(CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 2025.2 AND CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 2025.3)
+
+  message(STATUS "Working around ifx ${CMAKE_Fortran_COMPILER_VERSION} FPP bug (using external cpp -P)")
+
+  # Find a preprocessor; prefer 'cpp', fall back to 'clang-cpp'
+  find_program(cpp_exe NAMES cpp clang-cpp)
+  if(NOT cpp_exe)
+    message(FATAL_ERROR "ifx 2025.2 workaround requested but no 'cpp' or 'clang-cpp' found")
+  endif()
+  message(STATUS "Found preprocessor: ${cpp_exe}")
+
+  # Make a small wrapper that injects -P (no linemarkers)
+  set(cpp_wrapper "${CMAKE_BINARY_DIR}/tools/cpp_no_lines")
+  file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/tools")
+
+  if(WIN32)
+    # If you actually build on Windows with ifx, create a .bat wrapper
+    file(WRITE "${cpp_wrapper}.bat"
+"@echo off\r
+\"${cpp_exe}\" -P -traditional-cpp -undef %*\r
+")
+    set(cpp "-fpp-name=${cpp_wrapper}.bat")
+  else()
+    file(WRITE "${cpp_wrapper}"
+"#!/usr/bin/env bash
+exec \"${cpp_exe}\" -P -traditional-cpp -undef \"$@\"
+")
+    file(CHMOD "${cpp_wrapper}" FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+    set(cpp "-fpp-name=${cpp_wrapper}")
+  endif()
+endif()
+
 set (SUPPRESS_LINE_LENGTH_WARNING "-diag-disable 5268")
-set (CMAKE_Fortran_FLAGS_RELEASE "${FPP_FLAG} -O3 -free -stand f08 ${SUPPRESS_LINE_LENGTH_WARNING}")
-set (CMAKE_Fortran_FLAGS_DEBUG   "${FPP_FLAG} -O0 -g -traceback \
+set (CMAKE_Fortran_FLAGS_RELEASE "${cpp} -O3 -free -stand f08 ${SUPPRESS_LINE_LENGTH_WARNING}")
+set (CMAKE_Fortran_FLAGS_DEBUG   "${cpp} -O0 -g -traceback \
       -check nouninit -free -stand f08 -save-temps ${SUPPRESS_LINE_LENGTH_WARNING}")
 


### PR DESCRIPTION
This PR has a CMake workaround for an ifx 2025.2 bug in their preprocessor, see https://community.intel.com/t5/Intel-Fortran-Compiler/Regression-with-fpp-2025-2-0/td-p/1703735

This bug will be fixed in ifx 2025.3, but there is a need to get ifx 2025.2 working (as it fixes bugs in other repos, e.g., fms).

Note: This should be taken in concert with:

- https://github.com/Goddard-Fortran-Ecosystem/yaFyaml/pull/88
- https://github.com/Goddard-Fortran-Ecosystem/pFUnit/pull/500

cc: @climbfuji

---

As GitHub will soon drop support for macOS 13, we are updating our CI workflows to use macOS 15. Additionally, we are adding support for gfortran-15 to ensure compatibility with the latest Fortran compiler.