### PR TITLE
Prepare for 1.17.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 # ------------------------------------------------------------------------ #
 cmake_minimum_required (VERSION 3.24)
 project (PFLOGGER
-  VERSION 1.16.1
+  VERSION 1.17.0
   LANGUAGES Fortran)
 
 set (CMAKE_MODULE_PATH
@@ -34,13 +34,13 @@ include (DefinePlatformDefaults)
 set (CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 if (NOT TARGET GFTL::gftl)
-  find_package (GFTL REQUIRED VERSION 1.10.0)
+  find_package (GFTL REQUIRED VERSION 1.16.0)
 endif ()
 if (NOT TARGET GFTL_SHARED::gftl-shared)
-  find_package (GFTL_SHARED REQUIRED VERSION 1.6.0)
+  find_package (GFTL_SHARED REQUIRED VERSION 1.11.0)
 endif ()
 if (NOT TARGET YAFYAML::yafyaml)
-  find_package (YAFYAML REQUIRED VERSION 1.3.0)
+  find_package (YAFYAML REQUIRED VERSION 1.6.0)
 endif ()
 
 option (ENABLE_MPI "Enable MPI support" ON)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,12 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.0] - 2025-09-30
+
 ### Fixed
 
 - Workaround for `ifx` 2025.2 preprocessor bug
 
 ### Changed
 
+- Updated required version of gFTL to v1.16.0
+- Updated required version of gFTL-shared to v1.11.0
+- Updated required version of yaFyaml to v1.6.0
 - Update CMake minimum version to 3.24
 - Remove `macos-13` from CI, add `macos-15`
 - Add `gfortran-15` to macOS CI


### PR DESCRIPTION
This is a prep PR. We update the `find_package` for gFTL, gFTL-shared, and yafyaml to their latest (since ifx 2025.2 would need at least the latter)