### PR TITLE
Add get_handler(name) to LoggerManager (#155)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `get_handler(name)` public method to `LoggerManager` (#155). Returns a pointer to a named handler from the configuration registry, or a null pointer if the name is not found. Enables user code to attach globally-defined handlers (configured via `load_file`/`load_config`) to dynamically-created loggers without accessing private internals.
+
 ### Changed
 
 - Refactored configuration system to use Builder pattern

--- a/src/LoggerManager.F90
+++ b/src/LoggerManager.F90
@@ -57,6 +57,8 @@ module PFL_LoggerManager
       procedure :: build_root_logger
       procedure :: basic_config
 
+      procedure :: get_handler
+
       procedure :: free
    end type LoggerManager
    
@@ -493,6 +495,28 @@ contains
       end function 
 
    end subroutine basic_config
+
+   !---------------------------------------------------------------------------
+   ! FUNCTION:
+   ! get_handler
+   !
+   ! DESCRIPTION:
+   ! Return a pointer to the named handler from the manager's configuration
+   ! registry.  Returns a null pointer if no handler with that name has been
+   ! registered.
+   !---------------------------------------------------------------------------
+   function get_handler(this, name) result(handler)
+      class(AbstractHandler), pointer :: handler
+      class(LoggerManager), target, intent(in) :: this
+      character(len=*), intent(in) :: name
+
+      type(HandlerMap), pointer :: hdlMapPtr
+
+      hdlMapPtr => this%config%get_handlers()
+      handler => hdlMapPtr%at(name)
+
+   end function get_handler
+
 
    subroutine free(this)
       class(LoggerManager), intent(inout) :: this

--- a/tests/Test_LoggerManager.pf
+++ b/tests/Test_LoggerManager.pf
@@ -5,6 +5,7 @@ module Test_LoggerManager
    use PFL_Logger
    use PFL_RootLogger
    use PFL_SeverityLevels
+   use PFL_StringHandlerMap
    implicit none
 
 contains
@@ -250,6 +251,48 @@ contains
       @assertEqual('', buffer%buffer)
 
    end subroutine test_propagate_off
-   
+
+
+   @test
+   subroutine test_get_handler_found()
+      use MockHandler_mod
+      use PFL_AbstractHandler
+      type (LoggerManager), target :: manager
+      type (HandlerMap), pointer :: hdlMapPtr
+      type (MockBuffer), target :: buffer
+      type (MockHandler) :: h
+      class (AbstractHandler), pointer :: retrieved
+
+      manager = LoggerManager(RootLogger(WARNING))
+
+      ! Insert a named handler directly into the config's handler map
+      h = MockHandler(buffer)
+      hdlMapPtr => manager%config%get_handlers()
+      call hdlMapPtr%insert('console', h)
+
+      ! Retrieve via the public API
+      retrieved => manager%get_handler('console')
+
+      @assertTrue(associated(retrieved))
+      @assertTrue(same_type_as(retrieved, h))
+
+   end subroutine test_get_handler_found
+
+
+   @test
+   subroutine test_get_handler_not_found()
+      use PFL_AbstractHandler
+      type (LoggerManager), target :: manager
+      class (AbstractHandler), pointer :: retrieved
+
+      manager = LoggerManager(RootLogger(WARNING))
+
+      ! Retrieve a handler that was never registered
+      retrieved => manager%get_handler('nonexistent')
+
+      @assertFalse(associated(retrieved))
+
+   end subroutine test_get_handler_not_found
+
 
 end module Test_LoggerManager


### PR DESCRIPTION
## Summary

- Adds a public `get_handler(name)` method to `LoggerManager` that returns a pointer to a named handler from the configuration registry, or a null pointer if the name is not found.
- Enables user code to attach globally-defined handlers (configured via `load_file`/`load_config`) to dynamically-created loggers without accessing private internals.
- Adds two unit tests to `Test_LoggerManager.pf`: one covering successful retrieval and one covering the null-return case for an unregistered name.

## Related Issue

Closes #155

## API

```fortran
function get_handler(this, name) result(handler)
   class(AbstractHandler), pointer :: handler
   class(LoggerManager), target, intent(in) :: this
   character(len=*), intent(in) :: name
end function get_handler
```

## Example Usage

```fortran
handler => logging%get_handler('console')
if (associated(handler)) call my_logger%add_handler(handler)
```