### PR TITLE
hotfix: Fix broken parent-pointer chain for YAML-configured loggers (v1.18.1)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,20 +10,22 @@ on:
       - "LICENSE.pdf"
       - "COPYRIGHT"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   GNU:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-15, macos-26]
         compiler: [gfortran-12, gfortran-13, gfortran-14, gfortran-15]
-        # gfortran-10 and -11 are only on ubuntu-22.04
+        # gfortran-11 is only on ubuntu-22.04
         # gfortran-13 and -14 and -15 are not on ubuntu-22.04
         # gfortran-12 is not on macos
-        # gfortran-15 is only on macos
+        # gfortran-15 is only on macos (and ubuntu-24.04+ does not have it)
         include:
-          - os: ubuntu-22.04
-            compiler: gfortran-10
           - os: ubuntu-22.04
             compiler: gfortran-11
         exclude:
@@ -35,9 +37,9 @@ jobs:
             compiler: gfortran-15
           - os: ubuntu-24.04
             compiler: gfortran-15
-          - os: macos-14
-            compiler: gfortran-12
           - os: macos-15
+            compiler: gfortran-12
+          - os: macos-26
             compiler: gfortran-12
 
       # fail-fast if set to 'true' here is good for production, but when
@@ -90,7 +92,7 @@ jobs:
           cmake --build build --parallel 4 --target tests || ctest --test-dir build --parallel 1 --output-on-failure --repeat until-pass:4
 
       - name: Archive log files on failure
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: logfiles-${{ matrix.compiler }}-${{ matrix.os }}
@@ -161,7 +163,7 @@ jobs:
           cmake --build build --parallel 4 --target tests || ctest --test-dir build --parallel 1 --output-on-failure --repeat until-pass:4
 
       - name: Archive log files on failure
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: logfiles-Intel
@@ -172,9 +174,12 @@ jobs:
   #      we have to do some tricks to get it to run in GitHub Actions.
   Nvidia-Build-Only:
     runs-on: ubuntu-24.04
+    # Turned off for now because NVHPC image is too large for free
+    # GitHub Actions runners, but leaving here for when we can run it again
+    if: true
     env:
       FC: nvfortran
-      NVHPC_IMAGE: nvcr.io/nvidia/nvhpc:25.11-devel-cuda13.0-ubuntu24.04
+      NVHPC_IMAGE: nvcr.io/nvidia/nvhpc:26.3-devel-cuda13.1-ubuntu24.04
 
     steps:
       # Reclaim lots of space
@@ -209,8 +214,21 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Pull NVHPC image
-        run: docker pull "$NVHPC_IMAGE"
+      - name: Pull NVHPC image (retry)
+        env:
+          DOCKER_CLIENT_TIMEOUT: 600
+          COMPOSE_HTTP_TIMEOUT: 600
+        run: |
+          set -euo pipefail
+          for i in 1 2 3 4 5; do
+            echo "Attempt $i: docker pull $NVHPC_IMAGE"
+            if docker pull "$NVHPC_IMAGE"; then
+              exit 0
+            fi
+            sleep $((i*20))
+          done
+          echo "Docker pull failed after retries"
+          exit 1
 
       # Run everything inside the NVHPC container
       - name: Build (inside NVHPC)
@@ -250,7 +268,7 @@ jobs:
 
       - name: Archive log files on failure
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: logfiles-Nvidia
           path: |
@@ -307,7 +325,7 @@ jobs:
           cmake --build build --parallel 4 --target tests || ctest --test-dir build --parallel 1 --output-on-failure --repeat until-pass:4
 
       - name: Archive log files on failure
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: logfiles-Flang

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,6 +105,10 @@ jobs:
     env:
       FC: ifx
       CC: icx
+      # Pinned to 2025.3 because oneAPI 2026.0 has issues with yaFyaml and pFlogger tests.
+      # See: https://github.com/Goddard-Fortran-Ecosystem/GFE/actions/runs/24901429504/job/72919871357?pr=55
+      INTEL_ONEAPI_VERSION: "2025.3"
+      INTEL_MPI_VERSION: "2021.17"
 
     name: Intel Fortran
     steps:
@@ -126,12 +130,12 @@ jobs:
 
       - name: Install Intel oneAPI compilers
         timeout-minutes: 5
-        run: sudo apt-get install intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp
+        run: sudo apt-get install intel-oneapi-compiler-fortran-${{ env.INTEL_ONEAPI_VERSION }} intel-oneapi-compiler-dpcpp-cpp-${{ env.INTEL_ONEAPI_VERSION }}
 
       # optional
       - name: Install Intel MPI
         timeout-minutes: 5
-        run: sudo apt-get install intel-oneapi-mpi intel-oneapi-mpi-devel
+        run: sudo apt-get install intel-oneapi-mpi-${{ env.INTEL_MPI_VERSION }} intel-oneapi-mpi-devel-${{ env.INTEL_MPI_VERSION }}
 
       - name: Setup Intel oneAPI environment
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 # ------------------------------------------------------------------------ #
 cmake_minimum_required (VERSION 3.24)
 project (PFLOGGER
-  VERSION 1.18.0
+  VERSION 1.18.1
   LANGUAGES Fortran)
 
 set (CMAKE_MODULE_PATH

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -28,6 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   loader. Three regression tests have been added to `Test_yaFyaml_ConfigBuilder.pf`
   to catch this class of bug going forward.
 
+### Changed
+
+- Added `concurrency` group to CI workflow to cancel in-progress runs when a new commit is pushed to the same PR
+- Removed `macos-14` (Sonoma) from the CI runner matrix; it is deprecated upstream and two OS releases behind
+- Added `macos-26` (macOS Tahoe) to the GNU CI runner matrix
+- Updated `actions/upload-artifact` from v6 to v7 in `main.yml`
+
 ## [1.18.0] - 2026-03-25
 
 ### Added

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.18.1] - 2026-05-05
+
+### Fixed
+
+- Fixed broken parent-pointer chain for loggers defined in YAML configuration (#162).
+  The 1.18.0 refactor to the Builder pattern introduced a regression where
+  `build_loggers_from_cfg()` inserted loggers directly into the logger map via
+  `loggers%set()`, bypassing `LoggerManager::get_logger()` which is responsible
+  for calling `fixup_ancestors()`. Without `fixup_ancestors()`, parent pointers
+  were left null for all config-defined loggers, causing two symptoms:
+  - `getEffectiveLevel()` returned `NOTSET` (0) instead of traversing the parent
+    chain, so all messages passed the `isEnabledFor` check (e.g., DEBUG messages
+    appeared even when the configured level was WARNING).
+  - `emit()` found no handlers via the broken parent chain and fell through to
+    the `last_resort` handler, producing incorrect output format.
+  The fix calls `fixup_ancestors()` for every logger in the map after
+  `build_loggers_from_cfg()` completes, and also as a safety net when
+  `get_logger()` is called for a logger that was pre-inserted by the config
+  loader. Three regression tests have been added to `Test_yaFyaml_ConfigBuilder.pf`
+  to catch this class of bug going forward.
+
 ## [1.18.0] - 2026-03-25
 
 ### Added

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `macos-14` (Sonoma) from the CI runner matrix; it is deprecated upstream and two OS releases behind
 - Added `macos-26` (macOS Tahoe) to the GNU CI runner matrix
 - Updated `actions/upload-artifact` from v6 to v7 in `main.yml`
+- Fixed Intel Fortran test to 2025.3 as 2026.0 has issues with pFlogger (see #161)
 
 ## [1.18.0] - 2026-03-25
 

--- a/src/LoggerManager.F90
+++ b/src/LoggerManager.F90
@@ -145,8 +145,6 @@ contains
           select type (tmp)
           type is (Logger)
              lgr => tmp
-             call this%fixup_ancestors(lgr, rc=status)
-             _VERIFY(status,'',rc)
           type is (Placeholder)
             block
               type (Placeholder) :: ph

--- a/src/LoggerManager.F90
+++ b/src/LoggerManager.F90
@@ -141,11 +141,11 @@ contains
 
       if (associated(tmp)) then
 
-          ! cast to Logger
-          select type (tmp)
-          type is (Logger)
-             lgr => tmp
-          type is (Placeholder)
+         ! cast to Logger
+         select type (tmp)
+         type is (Logger)
+            lgr => tmp
+         type is (Placeholder)
             block
               type (Placeholder) :: ph
 

--- a/src/LoggerManager.F90
+++ b/src/LoggerManager.F90
@@ -141,11 +141,13 @@ contains
 
       if (associated(tmp)) then
 
-         ! cast to Logger
-         select type (tmp)
-         type is (Logger)
-            lgr => tmp
-         type is (Placeholder)
+          ! cast to Logger
+          select type (tmp)
+          type is (Logger)
+             lgr => tmp
+             call this%fixup_ancestors(lgr, rc=status)
+             _VERIFY(status,'',rc)
+          type is (Placeholder)
             block
               type (Placeholder) :: ph
 
@@ -377,9 +379,29 @@ contains
       integer, optional, intent(out) :: rc
 
       integer :: status
+      type (LoggerIterator) :: iter
+      class (AbstractLogger), pointer :: tmp
+      class (Logger), pointer :: lgr
 
       call this%builder%build_loggers_from_cfg(this%loggers, this%config, extra=extra, rc=status)
       _VERIFY(status, '', rc)
+
+      ! After all loggers are inserted, fix up parent pointers for each.
+      ! build_loggers_from_cfg inserts loggers directly into the map,
+      ! bypassing get_logger() which would normally call fixup_ancestors.
+      associate (b => this%loggers%begin(), e => this%loggers%end())
+        iter = b
+        do while (iter /= e)
+           tmp => iter%second()
+           select type (tmp)
+           type is (Logger)
+              lgr => tmp
+              call this%fixup_ancestors(lgr, rc=status)
+              _VERIFY(status, '', rc)
+           end select
+           call iter%next()
+        end do
+      end associate
 
       _RETURN(_SUCCESS,rc)
       _UNUSED_DUMMY(unusable)

--- a/tests/Test_yaFyaml_ConfigBuilder.pf
+++ b/tests/Test_yaFyaml_ConfigBuilder.pf
@@ -799,5 +799,169 @@ contains
       
    end subroutine test_logger_root_level
 #endif
-   
+
+   ! Regression test for GitHub issue: multi-level logger hierarchy loaded from
+   ! YAML config must have parent pointers wired up by fixup_ancestors().
+   !
+   ! In pFlogger 1.18, build_loggers_from_cfg() inserted loggers directly into
+   ! the loggers map via loggers%set(), bypassing get_logger() which calls
+   ! fixup_ancestors().  This left parent pointers null for config-defined
+   ! loggers, causing two bugs:
+   !   1. getEffectiveLevel() returned NOTSET (0), so all messages passed the
+   !      isEnabledFor check (debug messages appeared despite WARNING level).
+   !   2. emit() found no handlers via the broken parent chain and fell through
+   !      to last_resort, producing wrong format output.
+
+   @test
+   subroutine test_multilevel_logger_parent_chain()
+      ! Verify that after load_config(), a two-level logger hierarchy has
+      ! correct parent pointers: CAP.EXTDATA -> CAP -> ROOT_LOGGER.
+      !
+      ! Regression: in pFlogger 1.18, build_loggers_from_cfg() inserted
+      ! loggers via loggers%set(), bypassing get_logger() / fixup_ancestors(),
+      ! leaving parent pointers null for all config-defined loggers.
+      use PFL_RootLogger
+
+      class(YAML_Node), allocatable :: cfg
+      type (LoggerManager), target :: mgr
+      type (yaFyaml_ConfigBuilder) :: builder
+      class (Logger), pointer :: lgr_cap, lgr_extdata
+      class (Logger), pointer :: parent
+
+      call load(cfg, EscapedTextStream( &
+           & "  schema_version: 1 \n" // &
+           & "  loggers:   \n" // &
+           & "      CAP:         \n" // &
+           & "         level: WARNING \n" // &
+           & "      CAP.EXTDATA:  \n" // &
+           & "         level: WARNING \n"))
+
+      call builder%load_from_node(cfg)
+      mgr = LoggerManager(RootLogger(WARNING))
+      call mgr%set_builder(builder)
+      call mgr%load_config()
+
+      lgr_extdata => mgr%get_logger('CAP.EXTDATA')
+      lgr_cap     => mgr%get_logger('CAP')
+
+      ! CAP.EXTDATA's parent must be CAP (not root or null)
+      parent => lgr_extdata%get_parent()
+      @assertTrue(associated(parent), 'CAP.EXTDATA parent must not be null')
+      @assertEqual('CAP', parent%get_name())
+
+      ! CAP's parent must be ROOT_LOGGER
+      parent => lgr_cap%get_parent()
+      @assertTrue(associated(parent), 'CAP parent must not be null')
+      @assertEqual('ROOT_LOGGER', parent%get_name())
+
+   end subroutine test_multilevel_logger_parent_chain
+
+
+   @test
+   subroutine test_multilevel_logger_effective_level()
+      ! Verify that getEffectiveLevel() correctly traverses the parent chain
+      ! for a config-defined multi-level logger hierarchy.
+      !
+      ! Regression: if parent pointers are null (the 1.18 bug), getEffectiveLevel()
+      ! returns NOTSET (0) and all messages pass isEnabledFor, causing debug
+      ! messages to appear even when the effective level should be WARNING.
+      use PFL_RootLogger
+
+      class(YAML_Node), allocatable :: cfg
+      type (LoggerManager), target :: mgr
+      type (yaFyaml_ConfigBuilder) :: builder
+      class (Logger), pointer :: lgr
+
+      ! CAP.EXTDATA has NOTSET level; it should inherit WARNING from CAP.
+      call load(cfg, EscapedTextStream( &
+           & "  schema_version: 1 \n" // &
+           & "  loggers:   \n" // &
+           & "      CAP:         \n" // &
+           & "         level: WARNING \n" // &
+           & "      CAP.EXTDATA:  \n" // &
+           & "         level: NOTSET \n"))
+
+      call builder%load_from_node(cfg)
+      mgr = LoggerManager(RootLogger(WARNING))
+      call mgr%set_builder(builder)
+      call mgr%load_config()
+
+      lgr => mgr%get_logger('CAP.EXTDATA')
+
+      ! Effective level must be WARNING (inherited from CAP), not NOTSET (0).
+      ! A NOTSET result (0) would indicate broken parent chain.
+      @assertEqual(WARNING, lgr%getEffectiveLevel(), &
+           & 'CAP.EXTDATA effective level should be WARNING (inherited from CAP)')
+
+      ! Debug messages must NOT pass the level check
+      @assertFalse(lgr%isEnabledFor(DEBUG), &
+           & 'DEBUG should not be enabled when effective level is WARNING')
+
+      ! Info messages must NOT pass the level check
+      @assertFalse(lgr%isEnabledFor(INFO), &
+           & 'INFO should not be enabled when effective level is WARNING')
+
+      ! Warning messages must pass the level check
+      @assertTrue(lgr%isEnabledFor(WARNING), &
+           & 'WARNING should be enabled when effective level is WARNING')
+
+   end subroutine test_multilevel_logger_effective_level
+
+
+   @test
+   subroutine test_multilevel_logger_handler_propagation()
+      ! Verify that messages from a config-defined child logger propagate
+      ! through the parent chain to the root handler.
+      !
+      ! Regression: with broken parent pointers, emit() found 0 handlers via
+      ! the chain and fell through to last_resort, producing wrong output.
+      use MockHandler_mod
+      use PFL_RootLogger
+      use PFL_Formatter
+
+      class(YAML_Node), allocatable :: cfg
+      type (LoggerManager), target :: mgr
+      type (yaFyaml_ConfigBuilder) :: builder
+      class (Logger), pointer :: lgr
+      type (MockHandler) :: h
+      type (MockBuffer), target :: buffer
+
+      ! Root logger at INFO; child loggers at NOTSET (inherit INFO from root).
+      ! A MockHandler is attached to the root logger.
+      ! An INFO message to CAP.EXTDATA must propagate up to the root handler.
+      call load(cfg, EscapedTextStream( &
+           & "  schema_version: 1 \n" // &
+           & "  loggers:   \n" // &
+           & "      CAP:         \n" // &
+           & "         level: NOTSET \n" // &
+           & "      CAP.EXTDATA:  \n" // &
+           & "         level: NOTSET \n"))
+
+      call builder%load_from_node(cfg)
+      mgr = LoggerManager(RootLogger(INFO))
+      call mgr%set_builder(builder)
+      call mgr%load_config()
+
+      ! Attach a MockHandler with a known formatter to the root logger
+      h = MockHandler(buffer)
+      call h%set_formatter(Formatter('%(message)a'))
+      call mgr%root_node%add_handler(h)
+
+      lgr => mgr%get_logger('CAP.EXTDATA')
+
+      buffer%buffer = ''
+      call lgr%info('hello from child')
+
+      ! The message must have reached the root handler
+      @assertEqual('hello from child', buffer%buffer, &
+           & 'INFO message from CAP.EXTDATA must propagate to root handler')
+
+      ! A debug message must NOT reach the handler (root is at INFO)
+      buffer%buffer = ''
+      call lgr%debug('should be filtered')
+      @assertEqual('', buffer%buffer, &
+           & 'DEBUG message must be filtered by root logger INFO level')
+
+   end subroutine test_multilevel_logger_handler_propagation
+
 end module Test_yaFyaml_ConfigBuilder


### PR DESCRIPTION
## Summary

Fixes the regression introduced in 1.18.0 where the Builder pattern refactor left parent pointers null for all loggers defined in YAML configuration, causing incorrect log filtering and wrong output format.

Closes #162

## Root Cause

`build_loggers_from_cfg()` inserted loggers directly into the logger map via `loggers%set()`, bypassing `LoggerManager::get_logger()` which is responsible for calling `fixup_ancestors()`. Without `fixup_ancestors()`, parent pointers were null for all config-defined loggers.

## Symptoms

- **Debug messages appeared despite `level: WARNING`** — `getEffectiveLevel()` walked the null parent chain and returned `NOTSET` (0), so all messages passed `isEnabledFor`.
- **Wrong output format** — `emit()` found 0 handlers via the broken chain and fell through to `last_resort`, which uses a default formatter instead of the configured one.

## Fix

- In `build_loggers()` (`LoggerManager.F90`): after `build_loggers_from_cfg()` inserts all loggers, iterate the map and call `fixup_ancestors()` for each.
- In `get_logger_name()`: add a safety-net `fixup_ancestors()` call for loggers that were pre-inserted by the config loader when a user later calls `get_logger()`.

## Changes

- `src/LoggerManager.F90` — the fix
- `tests/Test_yaFyaml_ConfigBuilder.pf` — three regression tests:
  - `test_multilevel_logger_parent_chain`: asserts correct parent pointers after config load
  - `test_multilevel_logger_effective_level`: asserts `getEffectiveLevel()` traverses the chain correctly
  - `test_multilevel_logger_handler_propagation`: asserts messages propagate to the right handler
- `CMakeLists.txt` — bump version to 1.18.1
- `ChangeLog.md` — add 1.18.1 entry