### PR TITLE
Work around ifx 2026.1 logger-manager assignment regression

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,10 +105,6 @@ jobs:
     env:
       FC: ifx
       CC: icx
-      # Pinned to 2025.3 because oneAPI 2026.0 has issues with yaFyaml and pFlogger tests.
-      # See: https://github.com/Goddard-Fortran-Ecosystem/GFE/actions/runs/24901429504/job/72919871357?pr=55
-      INTEL_ONEAPI_VERSION: "2025.3"
-      INTEL_MPI_VERSION: "2021.17"
 
     name: Intel Fortran
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,12 +126,12 @@ jobs:
 
       - name: Install Intel oneAPI compilers
         timeout-minutes: 5
-        run: sudo apt-get install intel-oneapi-compiler-fortran-${{ env.INTEL_ONEAPI_VERSION }} intel-oneapi-compiler-dpcpp-cpp-${{ env.INTEL_ONEAPI_VERSION }}
+        run: sudo apt-get install intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp
 
       # optional
       - name: Install Intel MPI
         timeout-minutes: 5
-        run: sudo apt-get install intel-oneapi-mpi-${{ env.INTEL_MPI_VERSION }} intel-oneapi-mpi-devel-${{ env.INTEL_MPI_VERSION }}
+        run: sudo apt-get install intel-oneapi-mpi intel-oneapi-mpi-devel
 
       - name: Setup Intel oneAPI environment
         run: |

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Work around the ifx 2026.1 intrinsic-assignment regression when initializing
+  the logger-manager singleton (#161).
+
 ### Changed
 
 - Update CI to match build matrix of GFE

--- a/src/LoggerManager.F90
+++ b/src/LoggerManager.F90
@@ -33,6 +33,7 @@ module PFL_LoggerManager
    public :: LoggerManager
    public :: initialize_logger_manager
    public :: logging ! singleton instance
+   public :: assignment(=)
 
 !!$   type, extends(Object) :: LoggerManager
    type :: LoggerManager
@@ -66,6 +67,10 @@ module PFL_LoggerManager
    interface LoggerManager
       module procedure new_LoggerManager
    end interface LoggerManager
+
+   interface assignment(=)
+      module procedure copy_LoggerManager
+   end interface assignment(=)
    
    type (LoggerManager), target, save :: logging
 
@@ -96,6 +101,17 @@ contains
       manager%loggers = LoggerMap()
 
    end function new_LoggerManager
+
+
+   subroutine copy_LoggerManager(lhs, rhs)
+       type(LoggerManager), intent(out) :: lhs
+       type(LoggerManager), intent(in) :: rhs
+
+       lhs%root_node = rhs%root_node
+       lhs%config = rhs%config
+       lhs%loggers = rhs%loggers
+       if (allocated(rhs%builder)) allocate(lhs%builder, source=rhs%builder)
+   end subroutine copy_LoggerManager
 
 
    !---------------------------------------------------------------------------  
@@ -305,7 +321,10 @@ contains
       use PFL_AbstractConfigBuilder
       class(AbstractConfigBuilder), intent(in) :: builder
       
-      logging = LoggerManager(RootLogger(WARNING))
+      ! Avoid intrinsic assignment of the singleton, which crashes in ifx 2026.1
+      ! while copying its unallocated polymorphic builder component.
+      logging%root_node = RootLogger(WARNING)
+      logging%loggers = LoggerMap()
       call logging%set_builder(builder)
 
    end subroutine initialize_logger_manager


### PR DESCRIPTION
## Summary

- Avoid aggregate intrinsic assignment when initializing the saved `logging` singleton.
- Provide defined `LoggerManager` assignment that copies regular components and allocates `builder` only when the source builder is allocated.
- Remove the oneAPI 2025.3/Intel MPI 2021.17 CI pin so current Intel releases are tested.

## Diagnosis

The original, valid statement is:

```fortran
logging = LoggerManager(RootLogger(WARNING))
```

It assigns a function result to the saved singleton. `LoggerManager` contains `RootLogger`, `LoggingConfig` (with gFTL maps), `LoggerMap`, and an unallocated `class(AbstractConfigBuilder), allocatable :: builder` component. With ifx 2026.1 this reaches Intel runtime `for_alloc_assign_v2` and segfaults while copying the aggregate. The identical application path passes with ifx 2025.3, and the failure remains at `-O0`.

A self-contained Fortran reproducer was reduced and tested separately for Intel: it models the nested defined assignments/maps plus an unallocated allocatable-polymorphic component. It segfaults with ifx 2026.1 through `do_alloc_assign`/`for_alloc_assign_v2` and prints PASS with ifx 2025.3. This supports treating the behavior as an ifx 2026.1 regression, not an invalid `LoggerManager` assignment in pFlogger.

## Why this implementation

The singleton now initializes `root_node` and `loggers` directly, then uses the established `set_builder` path. The defined assignment preserves `LoggerManager` copy semantics: it assigns `root_node`, `config`, and `loggers`, and it only allocates `builder` when the RHS has one. Therefore it avoids the failing top-level aggregate assignment without compiler-specific preprocessing or an `if ifx-version` branch.

This is deliberately narrow. Component assignments remain normal Fortran assignments; the change only removes the known failing aggregate path and ensures client `LoggerManager` assignment follows the same safe component-wise behavior.

## Relation to yaFyaml

pFlogger's original singleton crash is independent of yaFyaml. After this initialization succeeds, YAML config tests may continue far enough to exercise yaFyaml's separate ifx 2026.1 polymorphic-token-vector failure. That downstream failure is not evidence that this manager workaround is incomplete.

## Validation

- Retested successfully with ifx 2025.3 (151 pFlogger tests).
- Confirmed the original ifx 2026.1 singleton crash is bypassed; subsequent ifx 2026.1 YAML lexer failures are the separate upstream issue described above.